### PR TITLE
Automate ingredient input in schema

### DIFF
--- a/components/menu/menu-item-details.tsx
+++ b/components/menu/menu-item-details.tsx
@@ -30,7 +30,7 @@ export function MenuItemDetails({ item }: MenuItemDetailsProps) {
   if (item.ingredients && item.ingredients.length > 0) {
     accordionItems.push({
       name: "Ingredients",
-      items: item.ingredients,
+      items: item.ingredients.map((ingredient) => ingredient?.name || "").filter(Boolean),
     });
   }
 

--- a/sanity/queries/menu.ts
+++ b/sanity/queries/menu.ts
@@ -7,7 +7,11 @@ export const MENU_ITEMS_QUERY = defineQuery(`
     slug,
     description,
     price,
-    ingredients,
+    ingredients[]-> {
+      _id,
+      name,
+      slug
+    },
     allergens,
     isAvailable,
     isCombo,
@@ -53,7 +57,11 @@ export const ALL_MENU_ITEMS_QUERY = defineQuery(`
     slug,
     description,
     price,
-    ingredients,
+    ingredients[]-> {
+      _id,
+      name,
+      slug
+    },
     allergens,
     isAvailable,
     isCombo,
@@ -141,7 +149,11 @@ export const MENU_ITEM_BY_SLUGS_QUERY = defineQuery(`
       slug,
       description,
       price,
-      ingredients,
+      ingredients[]-> {
+        _id,
+        name,
+        slug
+      },
       allergens,
       isAvailable,
       isCombo,
@@ -184,7 +196,11 @@ export const MENU_ITEM_BY_SLUGS_QUERY = defineQuery(`
       slug,
       description,
       price,
-      ingredients,
+      ingredients[]-> {
+        _id,
+        name,
+        slug
+      },
       allergens,
       isAvailable,
       isCombo,
@@ -244,7 +260,11 @@ export const MENU_ITEMS_BY_CATEGORY_QUERY = defineQuery(`
     slug,
     description,
     price,
-    ingredients,
+    ingredients[]-> {
+      _id,
+      name,
+      slug
+    },
     allergens,
     isAvailable,
     isCombo,

--- a/sanity/schemaTypes/index.ts
+++ b/sanity/schemaTypes/index.ts
@@ -2,6 +2,7 @@ import { type SchemaTypeDefinition } from "sanity";
 
 import { blockContentType } from "./blockContentType";
 import { faqsType } from "./faqsType";
+import { ingredientType } from "./ingredientType";
 import { legalType } from "./legalType";
 import { menuCategoryType } from "./menuCategoryType";
 import { menuItemType } from "./menuItemType";
@@ -11,6 +12,7 @@ export const schema: { types: SchemaTypeDefinition[] } = {
   types: [
     blockContentType,
     faqsType,
+    ingredientType,
     legalType,
     menuCategoryType,
     menuItemType,

--- a/sanity/schemaTypes/ingredientType.ts
+++ b/sanity/schemaTypes/ingredientType.ts
@@ -1,0 +1,46 @@
+import { LemonIcon } from "@sanity/icons";
+import { defineField, defineType } from "sanity";
+
+export const ingredientType = defineType({
+	name: "ingredient",
+	title: "Ingredient",
+	type: "document",
+	icon: LemonIcon,
+	fields: [
+		defineField({
+			name: "name",
+			title: "Ingredient Name",
+			type: "string",
+			validation: (Rule) => Rule.required(),
+			description: "The name of the ingredient (e.g., Tomato, Cheese, Basil)",
+		}),
+		defineField({
+			name: "slug",
+			type: "slug",
+			options: {
+				source: "name",
+			},
+			validation: (Rule) => Rule.required(),
+			description: "Auto-generated URL-friendly identifier",
+		}),
+		defineField({
+			name: "description",
+			title: "Description",
+			type: "text",
+			rows: 3,
+			description: "Optional description of the ingredient (e.g., sourcing, preparation notes)",
+		}),
+	],
+	preview: {
+		select: {
+			title: "name",
+			subtitle: "description",
+		},
+		prepare({ title, subtitle }) {
+			return {
+				title,
+				subtitle: subtitle || "Ingredient",
+			};
+		},
+	},
+});

--- a/sanity/schemaTypes/menuItemType.ts
+++ b/sanity/schemaTypes/menuItemType.ts
@@ -75,8 +75,13 @@ export const menuItemType = defineType({
       title: "Ingredients",
       type: "array",
       group: "details",
-      of: [{ type: "string" }],
-      description: "List of ingredients used in this item",
+      of: [
+        {
+          type: "reference",
+          to: [{ type: "ingredient" }],
+        },
+      ],
+      description: "Select ingredients used in this item",
     }),
     defineField({
       name: "allergens",

--- a/sanity/structure.ts
+++ b/sanity/structure.ts
@@ -19,6 +19,7 @@ export const structure: StructureResolver = (S) =>
             .title("Menu Management")
             .items([
               S.documentTypeListItem("menuCategory").title("Categories"),
+              S.documentTypeListItem("ingredient").title("Ingredients"),
               S.listItem()
                 .title("Items by Category")
                 .child(
@@ -40,8 +41,13 @@ export const structure: StructureResolver = (S) =>
       ...S.documentTypeListItems().filter(
         (item) =>
           item.getId() &&
-          !["faqs", "siteConfig", "legal", "menuCategory", "menuItem"].includes(
-            item.getId()!
-          )
+          ![
+            "faqs",
+            "siteConfig",
+            "legal",
+            "menuCategory",
+            "menuItem",
+            "ingredient",
+          ].includes(item.getId()!)
       ),
     ]);

--- a/types/cms.d.ts
+++ b/types/cms.d.ts
@@ -124,7 +124,13 @@ export type MenuItem = {
     [internalGroqTypeReferenceTo]?: "menuCategory";
   }>;
   price?: number;
-  ingredients?: Array<string>;
+  ingredients?: Array<{
+    _ref: string;
+    _type: "reference";
+    _weak?: boolean;
+    _key: string;
+    [internalGroqTypeReferenceTo]?: "ingredient";
+  }>;
   allergens?: Array<string>;
   isAvailable?: boolean;
   isCombo?: boolean;
@@ -180,6 +186,17 @@ export type MenuCategory = {
     _key: string;
     [internalGroqTypeReferenceTo]?: "menuItem";
   }>;
+};
+
+export type Ingredient = {
+  _id: string;
+  _type: "ingredient";
+  _createdAt: string;
+  _updatedAt: string;
+  _rev: string;
+  name?: string;
+  slug?: Slug;
+  description?: string;
 };
 
 export type Legal = {
@@ -388,7 +405,7 @@ export type SanityAssetSourceData = {
   url?: string;
 };
 
-export type AllSanitySchemaTypes = SiteConfig | MenuItem | MenuCategory | Legal | Faqs | BlockContent | SanityImagePaletteSwatch | SanityImagePalette | SanityImageDimensions | SanityImageHotspot | SanityImageCrop | SanityFileAsset | SanityImageAsset | SanityImageMetadata | Geopoint | Slug | SanityAssetSourceData;
+export type AllSanitySchemaTypes = SiteConfig | MenuItem | MenuCategory | Ingredient | Legal | Faqs | BlockContent | SanityImagePaletteSwatch | SanityImagePalette | SanityImageDimensions | SanityImageHotspot | SanityImageCrop | SanityFileAsset | SanityImageAsset | SanityImageMetadata | Geopoint | Slug | SanityAssetSourceData;
 export declare const internalGroqTypeReferenceTo: unique symbol;
 // Source: sanity/queries/faqs.ts
 // Variable: FAQS_QUERY
@@ -469,7 +486,11 @@ export type MENU_ITEMS_QUERYResult = Array<{
   slug: Slug | null;
   description: string | null;
   price: number | null;
-  ingredients: Array<string> | null;
+  ingredients: Array<{
+    _id: string;
+    name: string | null;
+    slug: Slug | null;
+  }> | null;
   allergens: Array<string> | null;
   isAvailable: boolean | null;
   isCombo: boolean | null;
@@ -556,7 +577,11 @@ export type ALL_MENU_ITEMS_QUERYResult = Array<{
   slug: Slug | null;
   description: string | null;
   price: number | null;
-  ingredients: Array<string> | null;
+  ingredients: Array<{
+    _id: string;
+    name: string | null;
+    slug: Slug | null;
+  }> | null;
   allergens: Array<string> | null;
   isAvailable: boolean | null;
   isCombo: boolean | null;
@@ -703,7 +728,11 @@ export type MENU_ITEM_BY_SLUGS_QUERYResult = {
     slug: Slug | null;
     description: string | null;
     price: number | null;
-    ingredients: Array<string> | null;
+    ingredients: Array<{
+      _id: string;
+      name: string | null;
+      slug: Slug | null;
+    }> | null;
     allergens: Array<string> | null;
     isAvailable: boolean | null;
     isCombo: boolean | null;
@@ -788,7 +817,11 @@ export type MENU_ITEM_BY_SLUGS_QUERYResult = {
     slug: Slug | null;
     description: string | null;
     price: number | null;
-    ingredients: Array<string> | null;
+    ingredients: Array<{
+      _id: string;
+      name: string | null;
+      slug: Slug | null;
+    }> | null;
     allergens: Array<string> | null;
     isAvailable: boolean | null;
     isCombo: boolean | null;
@@ -909,7 +942,11 @@ export type MENU_ITEMS_BY_CATEGORY_QUERYResult = Array<{
   slug: Slug | null;
   description: string | null;
   price: number | null;
-  ingredients: Array<string> | null;
+  ingredients: Array<{
+    _id: string;
+    name: string | null;
+    slug: Slug | null;
+  }> | null;
   allergens: Array<string> | null;
   isAvailable: boolean | null;
   isCombo: boolean | null;
@@ -1072,7 +1109,11 @@ export type SITE_CONFIG_QUERYResult = {
     slug: Slug | null;
     description: string | null;
     price: number | null;
-    ingredients: Array<string> | null;
+    ingredients: Array<{
+      _id: string;
+      name: string | null;
+      slug: Slug | null;
+    }> | null;
     allergens: Array<string> | null;
     isAvailable: boolean | null;
     isCombo: boolean | null;


### PR DESCRIPTION
- Created new Ingredient schema type with name, slug, and optional description
- Updated MenuItem schema to use ingredient references instead of string array
- Modified all GROQ queries to populate ingredient references
- Updated menu item details component to display ingredient names
- Added Ingredients section to Sanity Studio under Menu management
- Updated TypeScript types to reflect new ingredient structure
- Maintained allergens as separate field (unchanged)

This change enables reusable ingredients across multiple menu items, following the same reference pattern as categories.