### PR TITLE
Verify sitemap covers all static pages

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -110,6 +110,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: "monthly" as const,
       priority: 0.5,
     },
+    {
+      url: `${SITE_CONFIG.URL}/cart`,
+      lastModified: new Date(),
+      changeFrequency: "daily" as const,
+      priority: 0.8,
+    },
     // Dynamic pages
     ...categoryEntries,
     ...itemEntries,


### PR DESCRIPTION
The /cart static route was missing from the sitemap configuration. Added it with daily change frequency and priority 0.8 to ensure it's properly indexed by search engines.