### PR TITLE
Make skeleton loading dynamic for grid view toggle

### DIFF
--- a/app/(static)/menu/[category]/page.tsx
+++ b/app/(static)/menu/[category]/page.tsx
@@ -170,7 +170,13 @@ export default async function MenuItemsByCategoryPage({ params }: PageProps) {
         )}
       </div>
 
-      <Suspense fallback={<MenuPageSkeleton />}>
+      <Suspense
+        fallback={
+          <MenuPageSkeleton
+            useGridLayout={siteConfig?.enableMenuPageGridView ?? true}
+          />
+        }
+      >
         <MenuPageContent
           menuItems={menuItems || []}
           filterData={
@@ -188,7 +194,7 @@ export default async function MenuItemsByCategoryPage({ params }: PageProps) {
   );
 }
 
-function MenuPageSkeleton() {
+function MenuPageSkeleton({ useGridLayout = true }: { useGridLayout?: boolean }) {
   return (
     <div className="pt-12 lg:grid lg:grid-cols-3 lg:gap-x-8 xl:grid-cols-4 container">
       <aside className="space-y-8">
@@ -209,27 +215,44 @@ function MenuPageSkeleton() {
         </div>
       </aside>
       <div className="mt-6 lg:col-span-2 lg:mt-0 xl:col-span-3">
-        <div className="space-y-6">
-          {Array.from({ length: 6 }).map((_, i) => (
-            <div key={i} className="flex gap-4 md:gap-6 py-6 border-b border-gray-200">
-              {/* Image skeleton */}
-              <Skeleton className="w-16 h-16 md:w-20 md:h-20 rounded-lg flex-shrink-0" />
-
-              {/* Content skeleton */}
-              <div className="flex-1 flex flex-col md:flex-row md:justify-between gap-2 md:gap-6">
-                <div className="flex-1 space-y-2">
-                  <Skeleton className="h-5 w-3/4" />
-                  <Skeleton className="h-4 w-1/4" />
-                  <Skeleton className="h-4 w-full hidden md:block" />
-                </div>
-                <div className="flex items-center md:flex-col gap-2 md:items-end">
-                  <Skeleton className="h-6 w-20" />
-                  <Skeleton className="h-9 w-32" />
+        {useGridLayout ? (
+          // Grid skeleton - matches MenuGrid layout
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+            {Array.from({ length: 8 }).map((_, i) => (
+              <div key={i} className="space-y-4">
+                <Skeleton className="aspect-square w-full rounded-lg" />
+                <div className="space-y-2">
+                  <Skeleton className="h-4 w-3/4" />
+                  <Skeleton className="h-4 w-1/2" />
+                  <Skeleton className="h-6 w-1/4" />
                 </div>
               </div>
-            </div>
-          ))}
-        </div>
+            ))}
+          </div>
+        ) : (
+          // List skeleton - matches MenuList layout
+          <div className="space-y-6">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div key={i} className="flex gap-4 md:gap-6 py-6 border-b border-gray-200">
+                {/* Image skeleton */}
+                <Skeleton className="w-16 h-16 md:w-20 md:h-20 rounded-lg flex-shrink-0" />
+
+                {/* Content skeleton */}
+                <div className="flex-1 flex flex-col md:flex-row md:justify-between gap-2 md:gap-6">
+                  <div className="flex-1 space-y-2">
+                    <Skeleton className="h-5 w-3/4" />
+                    <Skeleton className="h-4 w-1/4" />
+                    <Skeleton className="h-4 w-full hidden md:block" />
+                  </div>
+                  <div className="flex items-center md:flex-col gap-2 md:items-end">
+                    <Skeleton className="h-6 w-20" />
+                    <Skeleton className="h-9 w-32" />
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/app/(static)/menu/page.tsx
+++ b/app/(static)/menu/page.tsx
@@ -47,7 +47,13 @@ export default async function MenuItemsPage() {
         </p>
       </div>
 
-      <Suspense fallback={<MenuPageSkeleton />}>
+      <Suspense
+        fallback={
+          <MenuPageSkeleton
+            useGridLayout={siteConfig?.enableMenuPageGridView ?? true}
+          />
+        }
+      >
         <MenuPageContent
           menuItems={menuItems || []}
           filterData={
@@ -64,7 +70,7 @@ export default async function MenuItemsPage() {
   );
 }
 
-function MenuPageSkeleton() {
+function MenuPageSkeleton({ useGridLayout = true }: { useGridLayout?: boolean }) {
   return (
     <div className="pt-12 lg:grid lg:grid-cols-3 lg:gap-x-8 xl:grid-cols-4 container">
       <aside className="space-y-8">
@@ -85,27 +91,44 @@ function MenuPageSkeleton() {
         </div>
       </aside>
       <div className="mt-6 lg:col-span-2 lg:mt-0 xl:col-span-3">
-        <div className="space-y-6">
-          {Array.from({ length: 6 }).map((_, i) => (
-            <div key={i} className="flex gap-4 md:gap-6 py-6 border-b border-gray-200">
-              {/* Image skeleton */}
-              <Skeleton className="w-16 h-16 md:w-20 md:h-20 rounded-lg flex-shrink-0" />
-
-              {/* Content skeleton */}
-              <div className="flex-1 flex flex-col md:flex-row md:justify-between gap-2 md:gap-6">
-                <div className="flex-1 space-y-2">
-                  <Skeleton className="h-5 w-3/4" />
-                  <Skeleton className="h-4 w-1/4" />
-                  <Skeleton className="h-4 w-full hidden md:block" />
-                </div>
-                <div className="flex items-center md:flex-col gap-2 md:items-end">
-                  <Skeleton className="h-6 w-20" />
-                  <Skeleton className="h-9 w-32" />
+        {useGridLayout ? (
+          // Grid skeleton - matches MenuGrid layout
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+            {Array.from({ length: 8 }).map((_, i) => (
+              <div key={i} className="space-y-4">
+                <Skeleton className="aspect-square w-full rounded-lg" />
+                <div className="space-y-2">
+                  <Skeleton className="h-4 w-3/4" />
+                  <Skeleton className="h-4 w-1/2" />
+                  <Skeleton className="h-6 w-1/4" />
                 </div>
               </div>
-            </div>
-          ))}
-        </div>
+            ))}
+          </div>
+        ) : (
+          // List skeleton - matches MenuList layout
+          <div className="space-y-6">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div key={i} className="flex gap-4 md:gap-6 py-6 border-b border-gray-200">
+                {/* Image skeleton */}
+                <Skeleton className="w-16 h-16 md:w-20 md:h-20 rounded-lg flex-shrink-0" />
+
+                {/* Content skeleton */}
+                <div className="flex-1 flex flex-col md:flex-row md:justify-between gap-2 md:gap-6">
+                  <div className="flex-1 space-y-2">
+                    <Skeleton className="h-5 w-3/4" />
+                    <Skeleton className="h-4 w-1/4" />
+                    <Skeleton className="h-4 w-full hidden md:block" />
+                  </div>
+                  <div className="flex items-center md:flex-col gap-2 md:items-end">
+                    <Skeleton className="h-6 w-20" />
+                    <Skeleton className="h-9 w-32" />
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
Update skeleton loading to dynamically render either grid or list layout based on the enableMenuPageGridView site config setting.

Changes:
- Updated MenuPageSkeleton in both /menu/page.tsx and /menu/[category]/page.tsx to accept useGridLayout prop
- Grid skeleton matches MenuGrid layout (responsive grid with 8 cards, aspect-square images)
- List skeleton maintains original layout (6 items with horizontal card design)
- Both skeletons now properly reflect the actual content layout that will be displayed

This ensures a consistent loading experience that matches the final rendered layout.