### PR TITLE
Fix accordion state on cart increment

### DIFF
--- a/components/cart/item-row.tsx
+++ b/components/cart/item-row.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { motion } from "motion/react";
@@ -23,6 +24,7 @@ interface ItemRowProps {
 export function ItemRow({ item }: ItemRowProps) {
   const { incrementQuantity, decrementQuantity, removeItem, formatPrice } =
     useCart();
+  const [accordionValue, setAccordionValue] = useState<string | undefined>(undefined);
 
   const imageUrl = item.image?.asset
     ? urlFor(item.image.asset)
@@ -45,7 +47,7 @@ export function ItemRow({ item }: ItemRowProps) {
 
   // Reusable combo items UI component using proper Accordion
   const ComboItemsSection = () => (
-    <Accordion type="single" collapsible>
+    <Accordion type="single" collapsible value={accordionValue} onValueChange={setAccordionValue}>
       <AccordionItem value="combo-items" className="border-none">
         <AccordionTrigger className="py-0 text-sm text-muted-foreground hover:text-foreground hover:no-underline">
           <span className="font-medium">


### PR DESCRIPTION
Previously, the accordion in cart items would collapse when incrementing or decrementing item quantities. This was caused by the accordion being uncontrolled and losing its internal state during re-renders triggered by cart store updates.

This commit makes the accordion controlled by:
- Adding React useState to manage accordion open/closed state
- Passing value and onValueChange props to the Accordion component
- Each cart item now maintains its own independent accordion state

Fixes the issue where accordion state was lost on quantity changes.