### PR TITLE
Fix accordion animation in cart item card

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@import "tw-animate-css";
 @plugin "@tailwindcss/typography";
 @custom-variant dark (&:is(.dark *));
 
@@ -171,27 +172,6 @@
   --shadow-lg: var(--shadow-lg);
   --shadow-xl: var(--shadow-xl);
   --shadow-2xl: var(--shadow-2xl);
-
-  --animate-accordion-down: accordion-down 0.2s ease-out;
-  --animate-accordion-up: accordion-up 0.2s ease-out;
-
-  @keyframes accordion-down {
-    from {
-      height: 0;
-    }
-    to {
-      height: var(--radix-accordion-content-height);
-    }
-  }
-
-  @keyframes accordion-up {
-    from {
-      height: var(--radix-accordion-content-height);
-    }
-    to {
-      height: 0;
-    }
-  }
 }
 
 @layer base {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "eslint-config-next": "16.0.0",
     "react-email": "4.3.2",
     "tailwindcss": "^4",
+    "tw-animate-css": "^1.4.0",
     "typescript": "^5"
   }
 }


### PR DESCRIPTION
Removed the `layout` prop from motion.li wrapper in cart item row. This was causing the accordion to open instantly without smooth animation by interfering with the accordion's built-in animations from tw-animate-css.

Now the accordion uses only its own smooth animations on both desktop and mobile.