### PR TITLE
Fix card layout in Sweet Deals section

### DIFF
--- a/components/landing/stats.tsx
+++ b/components/landing/stats.tsx
@@ -42,7 +42,7 @@ export function Stats() {
   return (
     <MotionSection className="py-16 lg:py-20">
       <div className="container">
-        <div className="grid grid-cols-1 xl:grid-cols-2 gap-14">
+        <div className="grid grid-cols-1 xl:grid-cols-[3fr_7fr] gap-14">
           {/* Text Content */}
           <div className="flex flex-col gap-3">
             <p className="px-2 border border-primary/30 rounded-full bg-primary/10 text-xs font-medium leading-6 text-primary mb-2 w-fit mx-auto xl:mx-0">


### PR DESCRIPTION
This pull request makes a minor adjustment to the layout of the `Stats` component on the landing page. The change updates the grid column proportions to improve the visual balance of the section.

* Updated the grid layout in `components/landing/stats.tsx` to use `xl:grid-cols-[3fr_7fr]` instead of `xl:grid-cols-2`, providing a 3:7 column ratio for better content distribution.