### PR TITLE
Enable priority purchasing for featured items

### DIFF
--- a/app/(static)/menu/[category]/page.tsx
+++ b/app/(static)/menu/[category]/page.tsx
@@ -20,6 +20,7 @@ import { SITE_CONFIG_QUERY } from "@/sanity/queries/site-config";
 import type { SITE_CONFIG_QUERYResult } from "@/types/cms";
 import { urlFor } from "@/sanity/lib/image";
 import { createCollectionTag, createDocumentTag } from "@/sanity/lib/cache-tags";
+import { sortMenuItemsByCategoryFeatured } from "@/lib/utils";
 
 interface PageProps {
   params: Promise<{
@@ -162,6 +163,21 @@ export default async function MenuItemsByCategoryPage({ params }: PageProps) {
     notFound();
   }
 
+  // Extract global featured item IDs from siteConfig
+  const globalFeaturedItemIds =
+    siteConfig?.featuredMenuItems?.map((item) => item._id).filter(Boolean) || [];
+
+  // Extract category-specific featured item IDs from categoryData
+  const categoryFeaturedItemIds =
+    categoryData.featuredItems?.map((item) => item._id).filter(Boolean) || [];
+
+  // Sort menu items: global featured first, then category featured, then alphabetically
+  const sortedMenuItems = sortMenuItemsByCategoryFeatured(
+    menuItems || [],
+    globalFeaturedItemIds,
+    categoryFeaturedItemIds
+  );
+
   return (
     <main className="py-16 lg:pt-40">
       <div className="border-b border-gray-200 pb-10 container">
@@ -183,7 +199,7 @@ export default async function MenuItemsByCategoryPage({ params }: PageProps) {
         }
       >
         <MenuPageContent
-          menuItems={menuItems || []}
+          menuItems={sortedMenuItems}
           filterData={
             filterData || {
               categories: [],

--- a/app/(static)/menu/page.tsx
+++ b/app/(static)/menu/page.tsx
@@ -14,6 +14,7 @@ import { MenuPageContent } from "@/components/menu/menu-page-content";
 import { Skeleton } from "@/components/ui/skeleton";
 import type { Metadata } from "next";
 import { createCollectionTag } from "@/sanity/lib/cache-tags";
+import { sortMenuItemsByFeatured } from "@/lib/utils";
 
 export const metadata: Metadata = {
   title: "Menu",
@@ -37,6 +38,16 @@ export default async function MenuItemsPage() {
     }),
   ]);
 
+  // Extract featured item IDs from siteConfig
+  const featuredItemIds =
+    siteConfig?.featuredMenuItems?.map((item) => item._id).filter(Boolean) || [];
+
+  // Sort menu items: featured items first (in siteConfig order), then alphabetically
+  const sortedMenuItems = sortMenuItemsByFeatured(
+    menuItems || [],
+    featuredItemIds
+  );
+
   return (
     <main className="py-16 lg:pt-40">
       <div className="border-b border-gray-200 pb-10 container">
@@ -58,7 +69,7 @@ export default async function MenuItemsPage() {
         }
       >
         <MenuPageContent
-          menuItems={menuItems || []}
+          menuItems={sortedMenuItems}
           filterData={
             filterData || {
               categories: [],

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -12,3 +12,127 @@ export function assertValue<T>(v: T | undefined, errorMessage: string): T {
 
   return v;
 }
+
+/**
+ * Type definition for menu items used in sorting
+ */
+type SortableMenuItem = {
+  _id: string;
+  name?: string | null;
+  [key: string]: any;
+};
+
+/**
+ * Sorts menu items with featured items appearing first (in their featured order),
+ * followed by non-featured items in alphabetical order by name.
+ *
+ * @param items - Array of menu items to sort
+ * @param featuredItemIds - Array of featured item IDs in their display order
+ * @returns Sorted array with featured items first, then alphabetical items
+ */
+export function sortMenuItemsByFeatured<T extends SortableMenuItem>(
+  items: T[],
+  featuredItemIds: string[]
+): T[] {
+  // Create a map of featured item IDs to their priority index
+  const featuredIndexMap = new Map<string, number>();
+  featuredItemIds.forEach((id, index) => {
+    featuredIndexMap.set(id, index);
+  });
+
+  // Separate featured and non-featured items
+  const featuredItems: T[] = [];
+  const nonFeaturedItems: T[] = [];
+
+  items.forEach((item) => {
+    if (featuredIndexMap.has(item._id)) {
+      featuredItems.push(item);
+    } else {
+      nonFeaturedItems.push(item);
+    }
+  });
+
+  // Sort featured items by their order in featuredItemIds
+  featuredItems.sort((a, b) => {
+    const indexA = featuredIndexMap.get(a._id) ?? Infinity;
+    const indexB = featuredIndexMap.get(b._id) ?? Infinity;
+    return indexA - indexB;
+  });
+
+  // Sort non-featured items alphabetically by name
+  nonFeaturedItems.sort((a, b) => {
+    const nameA = (a.name || "").toLowerCase();
+    const nameB = (b.name || "").toLowerCase();
+    return nameA.localeCompare(nameB);
+  });
+
+  // Return featured items first, then non-featured items
+  return [...featuredItems, ...nonFeaturedItems];
+}
+
+/**
+ * Sorts menu items for category pages with multiple levels of featured priority:
+ * 1. Global featured items (from siteConfig) that belong to this category
+ * 2. Category-specific featured items
+ * 3. Non-featured items in alphabetical order
+ *
+ * @param items - Array of menu items to sort
+ * @param globalFeaturedItemIds - Array of global featured item IDs (from siteConfig)
+ * @param categoryFeaturedItemIds - Array of category-specific featured item IDs
+ * @returns Sorted array with global featured first, then category featured, then alphabetical
+ */
+export function sortMenuItemsByCategoryFeatured<T extends SortableMenuItem>(
+  items: T[],
+  globalFeaturedItemIds: string[],
+  categoryFeaturedItemIds: string[]
+): T[] {
+  // Create maps for both featured lists
+  const globalFeaturedIndexMap = new Map<string, number>();
+  globalFeaturedItemIds.forEach((id, index) => {
+    globalFeaturedIndexMap.set(id, index);
+  });
+
+  const categoryFeaturedIndexMap = new Map<string, number>();
+  categoryFeaturedItemIds.forEach((id, index) => {
+    categoryFeaturedIndexMap.set(id, index);
+  });
+
+  // Separate items into three groups
+  const globalFeaturedItems: T[] = [];
+  const categoryFeaturedItems: T[] = [];
+  const nonFeaturedItems: T[] = [];
+
+  items.forEach((item) => {
+    if (globalFeaturedIndexMap.has(item._id)) {
+      globalFeaturedItems.push(item);
+    } else if (categoryFeaturedIndexMap.has(item._id)) {
+      categoryFeaturedItems.push(item);
+    } else {
+      nonFeaturedItems.push(item);
+    }
+  });
+
+  // Sort global featured items by their order
+  globalFeaturedItems.sort((a, b) => {
+    const indexA = globalFeaturedIndexMap.get(a._id) ?? Infinity;
+    const indexB = globalFeaturedIndexMap.get(b._id) ?? Infinity;
+    return indexA - indexB;
+  });
+
+  // Sort category featured items by their order
+  categoryFeaturedItems.sort((a, b) => {
+    const indexA = categoryFeaturedIndexMap.get(a._id) ?? Infinity;
+    const indexB = categoryFeaturedIndexMap.get(b._id) ?? Infinity;
+    return indexA - indexB;
+  });
+
+  // Sort non-featured items alphabetically
+  nonFeaturedItems.sort((a, b) => {
+    const nameA = (a.name || "").toLowerCase();
+    const nameB = (b.name || "").toLowerCase();
+    return nameA.localeCompare(nameB);
+  });
+
+  // Return in priority order: global featured, category featured, then alphabetical
+  return [...globalFeaturedItems, ...categoryFeaturedItems, ...nonFeaturedItems];
+}

--- a/sanity/queries/menu.ts
+++ b/sanity/queries/menu.ts
@@ -249,6 +249,53 @@ export const CATEGORY_BY_SLUG_QUERY = defineQuery(`
     thumbnail {
       asset->,
       alt
+    },
+    featuredItems[]-> {
+      _id,
+      name,
+      slug,
+      description,
+      price,
+      ingredients[]-> {
+        _id,
+        name,
+        slug
+      },
+      allergens,
+      isAvailable,
+      isCombo,
+      comboDescription,
+      _createdAt,
+      _updatedAt,
+      comboItems[]-> {
+        _id,
+        name,
+        slug,
+        price,
+        isAvailable,
+        categories[]-> {
+          _id,
+          title,
+          slug
+        },
+        image {
+          asset->,
+          alt,
+          hotspot,
+          crop
+        }
+      },
+      categories[]-> {
+        _id,
+        title,
+        slug
+      },
+      image {
+        asset->,
+        alt,
+        hotspot,
+        crop
+      }
     }
   }
 `);

--- a/types/cms.d.ts
+++ b/types/cms.d.ts
@@ -903,7 +903,7 @@ export type MENU_ITEM_BY_SLUGS_QUERYResult = {
   }>;
 };
 // Variable: CATEGORY_BY_SLUG_QUERY
-// Query: *[_type == "menuCategory" && slug.current == $slug][0] {    _id,    title,    slug,    description,    thumbnail {      asset->,      alt    }  }
+// Query: *[_type == "menuCategory" && slug.current == $slug][0] {    _id,    title,    slug,    description,    thumbnail {      asset->,      alt    },    featuredItems[]-> {      _id,      name,      slug,      description,      price,      ingredients[]-> {        _id,        name,        slug      },      allergens,      isAvailable,      isCombo,      comboDescription,      _createdAt,      _updatedAt,      comboItems[]-> {        _id,        name,        slug,        price,        isAvailable,        categories[]-> {          _id,          title,          slug        },        image {          asset->,          alt,          hotspot,          crop        }      },      categories[]-> {        _id,        title,        slug      },      image {        asset->,        alt,        hotspot,        crop      }    }  }
 export type CATEGORY_BY_SLUG_QUERYResult = {
   _id: string;
   title: string | null;
@@ -934,6 +934,95 @@ export type CATEGORY_BY_SLUG_QUERYResult = {
     } | null;
     alt: string | null;
   } | null;
+  featuredItems: Array<{
+    _id: string;
+    name: string | null;
+    slug: Slug | null;
+    description: string | null;
+    price: number | null;
+    ingredients: Array<{
+      _id: string;
+      name: string | null;
+      slug: Slug | null;
+    }> | null;
+    allergens: Array<string> | null;
+    isAvailable: boolean | null;
+    isCombo: boolean | null;
+    comboDescription: string | null;
+    _createdAt: string;
+    _updatedAt: string;
+    comboItems: Array<{
+      _id: string;
+      name: string | null;
+      slug: Slug | null;
+      price: number | null;
+      isAvailable: boolean | null;
+      categories: Array<{
+        _id: string;
+        title: string | null;
+        slug: Slug | null;
+      }> | null;
+      image: {
+        asset: {
+          _id: string;
+          _type: "sanity.imageAsset";
+          _createdAt: string;
+          _updatedAt: string;
+          _rev: string;
+          originalFilename?: string;
+          label?: string;
+          title?: string;
+          description?: string;
+          altText?: string;
+          sha1hash?: string;
+          extension?: string;
+          mimeType?: string;
+          size?: number;
+          assetId?: string;
+          uploadId?: string;
+          path?: string;
+          url?: string;
+          metadata?: SanityImageMetadata;
+          source?: SanityAssetSourceData;
+        } | null;
+        alt: string | null;
+        hotspot: SanityImageHotspot | null;
+        crop: SanityImageCrop | null;
+      } | null;
+    }> | null;
+    categories: Array<{
+      _id: string;
+      title: string | null;
+      slug: Slug | null;
+    }> | null;
+    image: {
+      asset: {
+        _id: string;
+        _type: "sanity.imageAsset";
+        _createdAt: string;
+        _updatedAt: string;
+        _rev: string;
+        originalFilename?: string;
+        label?: string;
+        title?: string;
+        description?: string;
+        altText?: string;
+        sha1hash?: string;
+        extension?: string;
+        mimeType?: string;
+        size?: number;
+        assetId?: string;
+        uploadId?: string;
+        path?: string;
+        url?: string;
+        metadata?: SanityImageMetadata;
+        source?: SanityAssetSourceData;
+      } | null;
+      alt: string | null;
+      hotspot: SanityImageHotspot | null;
+      crop: SanityImageCrop | null;
+    } | null;
+  }> | null;
 } | null;
 // Variable: MENU_ITEMS_BY_CATEGORY_QUERY
 // Query: *[_type == "menuItem" && $categorySlug in categories[]->slug.current] | order(name asc) {    _id,    name,    slug,    description,    price,    ingredients[]-> {      _id,      name,      slug    },    allergens,    isAvailable,    isCombo,    comboDescription,    _createdAt,    _updatedAt,    comboItems[]-> {      _id,      name,      slug,      price,      isAvailable,      categories[]-> {        _id,        title,        slug      },      image {        asset->,        alt,        hotspot,        crop      }    },    categories[]-> {      _id,      title,      slug    },    image {      asset->,      alt,      hotspot,      crop    }  }
@@ -1279,7 +1368,7 @@ declare module "@sanity/client" {
     "\n  *[_type == \"siteConfig\"][0].menuCategories[]-> {\n    _id,\n    title,\n    slug,\n    description,\n    thumbnail {\n      asset->,\n      alt,\n      hotspot,\n      crop\n    }\n  }\n": ALL_CATEGORIES_QUERYResult;
     "\n  {\n    \"categories\": *[_type == \"menuCategory\"] | order(title asc) {\n      _id,\n      title,\n      slug\n    },\n    \"allergens\": array::unique(*[_type == \"menuItem\" && defined(allergens)].allergens[]),\n    \"priceRange\": {\n      \"min\": math::min(*[_type == \"menuItem\" && defined(price)].price),\n      \"max\": math::max(*[_type == \"menuItem\" && defined(price)].price)\n    }\n  }\n": MENU_FILTERS_DATA_QUERYResult;
     "\n  {\n    \"item\": *[_type == \"menuItem\" && slug.current == $itemSlug && $categorySlug in categories[]->slug.current][0] {\n      _id,\n      name,\n      slug,\n      description,\n      price,\n      ingredients[]-> {\n        _id,\n        name,\n        slug\n      },\n      allergens,\n      isAvailable,\n      isCombo,\n      comboDescription,\n      _createdAt,\n      _updatedAt,\n      comboItems[]-> {\n        _id,\n        name,\n        slug,\n        price,\n        isAvailable,\n        categories[]-> {\n          _id,\n          title,\n          slug\n        },\n        image {\n          asset->,\n          alt,\n          hotspot,\n          crop\n        }\n      },\n      categories[]-> {\n        _id,\n        title,\n        slug\n      },\n      image {\n        asset->,\n        alt,\n        hotspot,\n        crop\n      }\n    },\n    \"relatedItems\": *[_type == \"menuItem\" && slug.current != $itemSlug && $categorySlug in categories[]->slug.current && isAvailable == true] | order(name asc) [0...4] {\n      _id,\n      name,\n      slug,\n      description,\n      price,\n      ingredients[]-> {\n        _id,\n        name,\n        slug\n      },\n      allergens,\n      isAvailable,\n      isCombo,\n      comboDescription,\n      _createdAt,\n      _updatedAt,\n      comboItems[]-> {\n        _id,\n        name,\n        slug,\n        price,\n        isAvailable,\n        categories[]-> {\n          _id,\n          title,\n          slug\n        },\n        image {\n          asset->,\n          alt,\n          hotspot,\n          crop\n        }\n      },\n      categories[]-> {\n        _id,\n        title,\n        slug\n      },\n      image {\n        asset->,\n        alt,\n        hotspot,\n        crop\n      }\n    }\n  }\n": MENU_ITEM_BY_SLUGS_QUERYResult;
-    "\n  *[_type == \"menuCategory\" && slug.current == $slug][0] {\n    _id,\n    title,\n    slug,\n    description,\n    thumbnail {\n      asset->,\n      alt\n    }\n  }\n": CATEGORY_BY_SLUG_QUERYResult;
+    "\n  *[_type == \"menuCategory\" && slug.current == $slug][0] {\n    _id,\n    title,\n    slug,\n    description,\n    thumbnail {\n      asset->,\n      alt\n    },\n    featuredItems[]-> {\n      _id,\n      name,\n      slug,\n      description,\n      price,\n      ingredients[]-> {\n        _id,\n        name,\n        slug\n      },\n      allergens,\n      isAvailable,\n      isCombo,\n      comboDescription,\n      _createdAt,\n      _updatedAt,\n      comboItems[]-> {\n        _id,\n        name,\n        slug,\n        price,\n        isAvailable,\n        categories[]-> {\n          _id,\n          title,\n          slug\n        },\n        image {\n          asset->,\n          alt,\n          hotspot,\n          crop\n        }\n      },\n      categories[]-> {\n        _id,\n        title,\n        slug\n      },\n      image {\n        asset->,\n        alt,\n        hotspot,\n        crop\n      }\n    }\n  }\n": CATEGORY_BY_SLUG_QUERYResult;
     "\n  *[_type == \"menuItem\" && $categorySlug in categories[]->slug.current] | order(name asc) {\n    _id,\n    name,\n    slug,\n    description,\n    price,\n    ingredients[]-> {\n      _id,\n      name,\n      slug\n    },\n    allergens,\n    isAvailable,\n    isCombo,\n    comboDescription,\n    _createdAt,\n    _updatedAt,\n    comboItems[]-> {\n      _id,\n      name,\n      slug,\n      price,\n      isAvailable,\n      categories[]-> {\n        _id,\n        title,\n        slug\n      },\n      image {\n        asset->,\n        alt,\n        hotspot,\n        crop\n      }\n    },\n    categories[]-> {\n      _id,\n      title,\n      slug\n    },\n    image {\n      asset->,\n      alt,\n      hotspot,\n      crop\n    }\n  }\n": MENU_ITEMS_BY_CATEGORY_QUERYResult;
     "\n  *[_type == \"menuItem\" && references($ingredientId)] {\n    _id,\n    \"slug\": slug.current\n  }\n": MENU_ITEMS_BY_INGREDIENT_QUERYResult;
     "{\n  \"categories\": *[\n    _type == \"menuCategory\" &&\n    (title match $searchTerm || description match $searchTerm)\n  ] | order(title asc) [0...10] {\n    _id,\n    title,\n    slug,\n    description\n  },\n\n  \"menuItems\": *[\n    _type == \"menuItem\" &&\n    isAvailable == true &&\n    (name match $searchTerm || description match $searchTerm)\n  ] | order(name asc) [0...10] {\n    _id,\n    name,\n    slug,\n    price,\n    categories[]-> {\n      slug\n    },\n    isAvailable\n  },\n\n  \"legal\": *[\n    _type == \"legal\" &&\n    (title match $searchTerm || description match $searchTerm)\n  ] | order(title asc) [0...10] {\n    _id,\n    title,\n    slug,\n    description\n  }\n}": COMMAND_SEARCH_QUERYResult;


### PR DESCRIPTION
- Add sorting utilities for menu items with featured priority
- Update menu page to display global featured items first
- Update category pages to display global featured items, then category featured items
- Featured items maintain siteConfig order, others remain alphabetical
- Update CATEGORY_BY_SLUG_QUERY to include category featured items
- Regenerate types to include new query fields

Cart display order remains unchanged (push-based)