### PR TITLE
Add transition effect to active navbar underline

### DIFF
--- a/components/layouts/navbar.tsx
+++ b/components/layouts/navbar.tsx
@@ -146,7 +146,10 @@ export function Navbar() {
                           )}
                         />
                         {isActiveNavItem(item) && (
-                          <span className="absolute -bottom-0.5 left-0 right-0 h-0.5 bg-primary transition-all duration-300" />
+                          <span
+                            className="absolute -bottom-0.5 left-0 right-0 h-0.5 bg-primary transition-all duration-300"
+                            style={{ viewTransitionName: 'navbar-underline' }}
+                          />
                         )}
                       </button>
 
@@ -221,7 +224,10 @@ export function Navbar() {
                     >
                       {item.label}
                       {isActiveNavItem(item) && (
-                        <span className="absolute -bottom-0.5 left-0 right-0 h-0.5 bg-primary transition-all duration-300" />
+                        <span
+                          className="absolute -bottom-0.5 left-0 right-0 h-0.5 bg-primary transition-all duration-300"
+                          style={{ viewTransitionName: 'navbar-underline' }}
+                        />
                       )}
                     </Link>
                   </li>


### PR DESCRIPTION
Implemented view-transition-name for the navbar active underline to enable smooth sliding animation when navigating between pages. The underline will now morph from the old active nav item to the new one during page transitions.